### PR TITLE
Optimization: initialize vectors with capacity

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub fn many0<I: Clone+InputLength, O, F>(input: I, mut f: F) -> IResult<I, Vec<O
   where F: FnMut(I) -> IResult<I, O> {
 
   let mut i = input;
-  let mut acc = Vec::new();
+  let mut acc = Vec::with_capacity(4);
 
   loop {
     let i_ = i.clone();
@@ -106,7 +106,7 @@ pub fn many1<I: Clone+InputLength, O, F>(input: I, mut f: F) -> IResult<I, Vec<O
   where F: FnMut(I) -> IResult<I, O> {
 
   let mut i = input;
-  let mut acc = Vec::new();
+  let mut acc = Vec::with_capacity(4);
 
   loop {
     let i_ = i.clone();


### PR DESCRIPTION
Experiment: http (nomfun)
=========================

I noticed nom uses `Vec::with_capacity(n)` sometimes instead of
`Vec::new()`, and it prompted me try using `with_capacity` here
too.

With the initial changes here the nomfun benchmarks run faster on
my machine, although still not as fast as nom's. I have *not*
don't extensive testing or analysis of how to best tune the
`with_capacity` parameters. There's a risk of over-tuning for
these particular benchmarks and/or my hardware.

Before
------

```
     Running target/release/deps/http-bdfdac33ce8955e7

running 4 tests
test bigger_test           ... bench:     358,323 ns/iter (+/- 22,498) = 298 MB/s
test httparse_example_test ... bench:       1,568 ns/iter (+/- 81) = 448 MB/s
test one_test              ... bench:       1,061 ns/iter (+/- 85) = 274 MB/s
test small_test            ... bench:      67,921 ns/iter (+/- 4,269) = 314 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured
```

After
-----

```
running 4 tests
test bigger_test           ... bench:     329,349 ns/iter (+/- 12,057) = 324 MB/s
test httparse_example_test ... bench:       1,497 ns/iter (+/- 58) = 469 MB/s
test one_test              ... bench:         928 ns/iter (+/- 48) = 313 MB/s
test small_test            ... bench:      64,177 ns/iter (+/- 2,568) = 333 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured
```

Control: nom-http
=================

```
     Running target/release/deps/nom_http-ad1be66dd0ecc9db

running 4 tests
test bigger_test           ... bench:     311,904 ns/iter (+/- 9,902) = 342 MB/s
test httparse_example_test ... bench:       1,469 ns/iter (+/- 103) = 478 MB/s
test one_test              ... bench:         885 ns/iter (+/- 52) = 328 MB/s
test small_test            ... bench:      64,150 ns/iter (+/- 1,288) = 333 MB/s

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured
```