### PR TITLE
optimize is_token function by using a bit table lookup

### DIFF
--- a/benches/http.rs
+++ b/benches/http.rs
@@ -30,29 +30,36 @@ struct Header<'a> {
 }
 
 fn is_token(c: u8) -> bool {
-    match c {
-        128...255 => false,
-        0...31    => false,
-        b'('      => false,
-        b')'      => false,
-        b'<'      => false,
-        b'>'      => false,
-        b'@'      => false,
-        b','      => false,
-        b';'      => false,
-        b':'      => false,
-        b'\\'     => false,
-        b'"'      => false,
-        b'/'      => false,
-        b'['      => false,
-        b']'      => false,
-        b'?'      => false,
-        b'='      => false,
-        b'{'      => false,
-        b'}'      => false,
-        b' '      => false,
-        _         => true,
-    }
+    const MASK: u128 = ((1 << b'(')
+        | (1 << b')')
+        | (1 << b'<')
+        | (1 << b'>')
+        | (1 << b'@')
+        | (1 << b',')
+        | (1 << b';')
+        | (1 << b':')
+        | (1 << b'\\')
+        | (1 << b'"')
+        | (1 << b'/')
+        | (1 << b'[')
+        | (1 << b']')
+        | (1 << b'?')
+        | (1 << b'=')
+        | (1 << b'{')
+        | (1 << b'}')
+        | (1 << b' '));
+    const M: [u32; 8] = [
+        0xffff_ffff,
+        (MASK >> 32) as u32,
+        (MASK >> 64) as u32,
+        (MASK >> 96) as u32,
+        0xffff_ffff,
+        0xffff_ffff,
+        0xffff_ffff,
+        0xffff_ffff,
+    ];
+
+    M[(c / 32) as usize] & (1 << (c % 32)) == 0
 }
 
 fn not_line_ending(c: u8) -> bool {

--- a/benches/nom-http.rs
+++ b/benches/nom-http.rs
@@ -28,29 +28,36 @@ struct Header<'a> {
 }
 
 fn is_token(c: u8) -> bool {
-    match c {
-        128...255 => false,
-        0...31    => false,
-        b'('      => false,
-        b')'      => false,
-        b'<'      => false,
-        b'>'      => false,
-        b'@'      => false,
-        b','      => false,
-        b';'      => false,
-        b':'      => false,
-        b'\\'     => false,
-        b'"'      => false,
-        b'/'      => false,
-        b'['      => false,
-        b']'      => false,
-        b'?'      => false,
-        b'='      => false,
-        b'{'      => false,
-        b'}'      => false,
-        b' '      => false,
-        _         => true,
-    }
+    const MASK: u128 = ((1 << b'(')
+        | (1 << b')')
+        | (1 << b'<')
+        | (1 << b'>')
+        | (1 << b'@')
+        | (1 << b',')
+        | (1 << b';')
+        | (1 << b':')
+        | (1 << b'\\')
+        | (1 << b'"')
+        | (1 << b'/')
+        | (1 << b'[')
+        | (1 << b']')
+        | (1 << b'?')
+        | (1 << b'=')
+        | (1 << b'{')
+        | (1 << b'}')
+        | (1 << b' '));
+    const M: [u32; 8] = [
+        0xffff_ffff,
+        (MASK >> 32) as u32,
+        (MASK >> 64) as u32,
+        (MASK >> 96) as u32,
+        0xffff_ffff,
+        0xffff_ffff,
+        0xffff_ffff,
+        0xffff_ffff,
+    ];
+
+    M[(c / 32) as usize] & (1 << (c % 32)) == 0
 }
 
 fn not_line_ending(c: u8) -> bool {


### PR DESCRIPTION
Not the kind of optimization you'd expected I think, but by optimizing is_token function, both http and nom-http perf improved and surprisingly it tight the gap.

Before:
```
     Running target/release/deps/http-bdfdac33ce8955e7

running 4 tests
test bigger_test           ... bench:     336,712 ns/iter (+/- 12,784) = 317 MB/s
test httparse_example_test ... bench:       1,466 ns/iter (+/- 130) = 479 MB/s
test one_test              ... bench:         909 ns/iter (+/- 105) = 320 MB/s
test small_test            ... bench:      64,565 ns/iter (+/- 4,983) = 331 MB/s

     Running target/release/deps/nom_http-ad1be66dd0ecc9db

running 4 tests
test bigger_test           ... bench:     286,989 ns/iter (+/- 15,202) = 372 MB/s
test httparse_example_test ... bench:       1,347 ns/iter (+/- 147) = 521 MB/s
test one_test              ... bench:         846 ns/iter (+/- 89) = 343 MB/s
test small_test            ... bench:      53,348 ns/iter (+/- 2,550) = 400 MB/s
```

After:

```
     Running target/release/deps/http-bdfdac33ce8955e7

running 4 tests
test bigger_test           ... bench:     221,248 ns/iter (+/- 10,592) = 483 MB/s
test httparse_example_test ... bench:         934 ns/iter (+/- 33) = 752 MB/s
test one_test              ... bench:         549 ns/iter (+/- 34) = 530 MB/s
test small_test            ... bench:      41,737 ns/iter (+/- 3,290) = 512 MB/s


     Running target/release/deps/nom_http-ad1be66dd0ecc9db

running 4 tests
test bigger_test           ... bench:     206,995 ns/iter (+/- 7,544) = 516 MB/s
test httparse_example_test ... bench:         893 ns/iter (+/- 30) = 787 MB/s
test one_test              ... bench:         506 ns/iter (+/- 9) = 575 MB/s
test small_test            ... bench:      38,039 ns/iter (+/- 1,179) = 562 MB/s
```

It is not as readable as the match case, I try to keep it close enough with the u128 const. My first attempt is slower but maybe simpler:
```rust
fn is_token_bit(c: u8) -> bool {
    const MASK: u128 = (0xffff_ffff
        | (1 << b'(')
        | (1 << b')')
        | (1 << b'<')
        | (1 << b'>')
        | (1 << b'@')
        | (1 << b',')
        | (1 << b';')
        | (1 << b':')
        | (1 << b'\\')
        | (1 << b'"')
        | (1 << b'/')
        | (1 << b'[')
        | (1 << b']')
        | (1 << b'?')
        | (1 << b'=')
        | (1 << b'{')
        | (1 << b'}')
        | (1 << b' '));
    c < 128 && (1 << c as u128) & MASK == 0
}
```

Then I tried multiple subdivision (u16 and u64) but it made statistically no difference with u32.