### PR TITLE
Eliminate spurious dependency on fnv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2018"
 [dependencies]
 nom = "4.2"
 bencher = "*"
-fnv = "*"
 jemallocator = "0.1.8"
+
+[dev-dependencies]
+fnv = "*"
 
 #[[bench]]
 #name = "json"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,6 @@ extern crate nom;
 #[macro_use]
 extern crate bencher;
 
-extern crate fnv;
-
-use fnv::FnvHashMap as HashMap;
 use bencher::{Bencher, black_box};
 
 use nom::{digit, be_u32, IResult, Err, ErrorKind, InputTakeAtPosition, Convert, recognize_float,


### PR DESCRIPTION
No functional change, but I got a bit worried when I saw `src/lib.rs` pull in `fnv`.